### PR TITLE
MessagePack serialization

### DIFF
--- a/parameter.c
+++ b/parameter.c
@@ -352,7 +352,7 @@ void parameter_vector_declare_with_default(parameter_t *p,
 
 uint16_t parameter_vector_dim(parameter_t *p)
 {
-    PARAMETER_ASSERT(p->type == _PARAM_TYPE_VECTOR || p->type == _PARAM_TYPE_VAR_VECTOR);
+    PARAMETER_ASSERT(p->type == _PARAM_TYPE_VECTOR);
     return p->value.vect.dim;
 }
 

--- a/parameter.c
+++ b/parameter.c
@@ -352,7 +352,7 @@ void parameter_vector_declare_with_default(parameter_t *p,
 
 uint16_t parameter_vector_dim(parameter_t *p)
 {
-    PARAMETER_ASSERT(p->type == _PARAM_TYPE_VECTOR);
+    PARAMETER_ASSERT(p->type == _PARAM_TYPE_VECTOR || p->type == _PARAM_TYPE_VAR_VECTOR);
     return p->value.vect.dim;
 }
 

--- a/parameter_msgpack.c
+++ b/parameter_msgpack.c
@@ -394,7 +394,9 @@ void parameter_msgpack_write_cmp(const parameter_namespace_t *ns,
     }
 
     for (param=ns->parameter_list; param!=NULL; param=param->next) {
-        map_size ++;
+        if (parameter_defined(param)) {
+            map_size ++;
+        }
     }
 
     cmp_write_map(cmp, map_size);
@@ -408,6 +410,10 @@ void parameter_msgpack_write_cmp(const parameter_namespace_t *ns,
     /* Write each parameter. */
     for (param=ns->parameter_list; param!=NULL; param=param->next) {
         success = true;
+
+        if (parameter_defined(param) == false) {
+            continue;
+        }
 
         switch(param->type) {
             case _PARAM_TYPE_SCALAR:

--- a/parameter_msgpack.h
+++ b/parameter_msgpack.h
@@ -22,6 +22,18 @@ int parameter_msgpack_read(parameter_namespace_t *ns,
                            parameter_msgpack_err_cb err_cb,
                            void *err_arg);
 
+/** Saves the given parameter tree to the given CMP context. */
+void parameter_msgpack_write_cmp(const parameter_namespace_t *ns,
+                                 cmp_ctx_t *cmp,
+                                 parameter_msgpack_err_cb err_cb,
+                                 void *err_arg);
+
+/** Saves the given parameter tree to the given buffer as MessagePack. */
+void parameter_msgpack_write(const parameter_namespace_t *ns,
+                             char *buf,
+                             size_t size,
+                             parameter_msgpack_err_cb err_cb,
+                             void *err_arg);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/msgpack_test.cpp
+++ b/tests/msgpack_test.cpp
@@ -1,4 +1,5 @@
-#include "CppUTest/TestHarness.h"
+#include <CppUTest/TestHarness.h>
+#include <CppUTestExt/MockSupport.h>
 #include "../parameter.h"
 #include "../parameter_msgpack.h"
 #include <cmp_mem_access/cmp_mem_access.h>
@@ -19,6 +20,7 @@ TEST_GROUP(MessagePackTestGroup)
     parameter_namespace_t a;
     parameter_t a_foo;
     parameter_t a_bar;
+    parameter_t a_baz;
 
     char buffer[1024];
     cmp_mem_access_t mem;
@@ -30,8 +32,14 @@ TEST_GROUP(MessagePackTestGroup)
         parameter_namespace_declare(&a, &rootns, "a");
         parameter_scalar_declare(&a_foo, &a, "foo");
         parameter_scalar_declare(&a_bar, &a, "bar");
+        parameter_integer_declare(&a_baz, &a, "baz");
 
         cmp_mem_access_init(&ctx, &mem, buffer, sizeof buffer);
+    }
+
+    void teardown()
+    {
+        mock().clear();
     }
 };
 
@@ -92,4 +100,212 @@ TEST(MessagePackTestGroup, CanChangeMultipleParameters)
 
     CHECK_EQUAL(12., parameter_scalar_get(&a_foo));
     CHECK_EQUAL(24., parameter_scalar_get(&a_bar));
+}
+
+TEST(MessagePackTestGroup, TestWrite)
+{
+    uint32_t map_size;
+    uint32_t name_len;
+    int32_t ival;
+    float val;
+    char name[128];
+
+    parameter_scalar_set(&a_foo, 42);
+    parameter_scalar_set(&a_bar, 60);
+    parameter_integer_set(&a_baz, 50);
+
+    parameter_msgpack_write_cmp(&rootns, &ctx, msgpack_error_cb, NULL);
+
+    cmp_mem_access_set_pos(&mem, 0);
+
+    // Root namespace has 1 value, which is a namespace
+    CHECK_TRUE(cmp_read_map(&ctx, &map_size));
+    CHECK_EQUAL(1, map_size);
+
+    name_len = sizeof(name);
+    CHECK_TRUE(cmp_read_str(&ctx, name, &name_len));
+    STRCMP_EQUAL("a", name);
+
+    // "/a" has 3 values, all of them being parameters
+    CHECK_TRUE(cmp_read_map(&ctx, &map_size));
+    CHECK_EQUAL(3, map_size);
+
+    name_len = sizeof(name);
+    CHECK_TRUE(cmp_read_str(&ctx, name, &name_len));
+    STRCMP_EQUAL("baz", name);
+
+    CHECK_TRUE(cmp_read_int(&ctx, &ival));
+    CHECK_EQUAL(50, ival);
+
+    name_len = sizeof(name);
+    CHECK_TRUE(cmp_read_str(&ctx, name, &name_len));
+    STRCMP_EQUAL("bar", name);
+
+    CHECK_TRUE(cmp_read_float(&ctx, &val));
+    CHECK_EQUAL(60., val);
+
+    name_len = sizeof(name);
+    CHECK_TRUE(cmp_read_str(&ctx, name, &name_len));
+    STRCMP_EQUAL("foo", name);
+
+    CHECK_TRUE(cmp_read_float(&ctx, &val));
+    CHECK_EQUAL(42., val);
+}
+
+TEST(MessagePackTestGroup, TestWriteVector)
+{
+    uint32_t map_size;
+    uint32_t name_len;
+    int32_t ival;
+    float val;
+
+    char name[128];
+    parameter_t array;
+    float array_val[3];
+    float array_init[] = {1., 2., 3.};
+
+    parameter_namespace_declare(&rootns, NULL, NULL);
+    parameter_namespace_declare(&a, &rootns, "a");
+    parameter_vector_declare(&array, &a, "array", array_val, 3);
+    parameter_vector_set(&array, array_init);
+
+    parameter_msgpack_write_cmp(&rootns, &ctx, msgpack_error_cb, NULL);
+
+    cmp_mem_access_set_pos(&mem, 0);
+
+    CHECK_TRUE(cmp_read_map(&ctx, &map_size));
+    name_len = sizeof(name);
+    CHECK_TRUE(cmp_read_str(&ctx, name, &name_len));
+
+    CHECK_TRUE(cmp_read_map(&ctx, &map_size));
+    name_len = sizeof(name);
+    CHECK_TRUE(cmp_read_str(&ctx, name, &name_len));
+    STRCMP_EQUAL("array", name);
+
+    CHECK_TRUE(cmp_read_array(&ctx, &map_size));
+    CHECK_EQUAL(3, map_size);
+
+    // Check that the values are correctly taken
+    for (int i = 0; i < 3; i++) {
+        float val;
+        CHECK_TRUE(cmp_read_float(&ctx, &val));
+        CHECK_EQUAL(array_init[i], val);
+    }
+}
+
+TEST(MessagePackTestGroup, TestWriteVariableVector)
+{
+    uint32_t map_size;
+    uint32_t name_len;
+    int32_t ival;
+    float val;
+
+    char name[128];
+    parameter_t array;
+    float array_val[5];
+    float array_init[] = {1., 2., 3.};
+
+    parameter_namespace_declare(&rootns, NULL, NULL);
+    parameter_namespace_declare(&a, &rootns, "a");
+    parameter_variable_vector_declare(&array, &a, "array", array_val, 5);
+
+    parameter_variable_vector_set(&array, array_init, 3);
+
+    parameter_msgpack_write_cmp(&rootns, &ctx, msgpack_error_cb, NULL);
+
+    cmp_mem_access_set_pos(&mem, 0);
+
+    CHECK_TRUE(cmp_read_map(&ctx, &map_size));
+    name_len = sizeof(name);
+    CHECK_TRUE(cmp_read_str(&ctx, name, &name_len));
+
+    CHECK_TRUE(cmp_read_map(&ctx, &map_size));
+    name_len = sizeof(name);
+    CHECK_TRUE(cmp_read_str(&ctx, name, &name_len));
+    STRCMP_EQUAL("array", name);
+
+    CHECK_TRUE(cmp_read_array(&ctx, &map_size));
+    CHECK_EQUAL(3, map_size);
+
+    // Check that the values are correctly taken
+    for (int i = 0; i < 3; i++) {
+        float val;
+        CHECK_TRUE(cmp_read_float(&ctx, &val));
+        CHECK_EQUAL(array_init[i], val);
+    }
+}
+
+TEST(MessagePackTestGroup, TestWriteString)
+{
+    uint32_t map_size;
+    uint32_t name_len;
+    int32_t ival;
+    float val;
+
+    parameter_t array;
+    char array_value[128];
+
+    char name[128];
+
+    parameter_namespace_declare(&rootns, NULL, NULL);
+
+    parameter_string_declare(&array, &rootns, "str",
+                              array_value, sizeof(array_value));
+
+    parameter_string_set(&array, "hello");
+
+    parameter_msgpack_write_cmp(&rootns, &ctx, msgpack_error_cb, NULL);
+
+    cmp_mem_access_set_pos(&mem, 0);
+
+    CHECK_TRUE(cmp_read_map(&ctx, &map_size));
+    CHECK_EQUAL(1, map_size);
+
+    name_len = sizeof(name);
+    CHECK_TRUE(cmp_read_str(&ctx, name, &name_len));
+    STRCMP_EQUAL("str", name);
+
+    name_len = sizeof(name);
+    CHECK_TRUE(cmp_read_str(&ctx, name, &name_len));
+    STRCMP_EQUAL("hello", name);
+}
+
+void log_problematic_id_callback(void *p, const char *id, const char *err)
+{
+    mock().actualCall("error").withParameter("id", id);
+}
+
+TEST(MessagePackTestGroup, TestWriteUnknownParameter)
+{
+    parameter_t bad_param;
+
+    parameter_namespace_declare(&rootns, NULL, NULL);
+
+    parameter_integer_declare(&bad_param, &rootns, "bad_param");
+
+    // Bogus type
+    bad_param.type = 99;
+
+    mock().expectOneCall("error").withParameter("id", "bad_param");
+    parameter_msgpack_write_cmp(&rootns, &ctx, log_problematic_id_callback, NULL);
+
+    mock().checkExpectations();
+}
+
+TEST(MessagePackTestGroup, TestWriteNotEnoughSpaceLeft)
+{
+    parameter_t param;
+
+    // Have a fake write buffer with only 2 bytes left
+    cmp_mem_access_init(&ctx, &mem, buffer, 2);
+
+    parameter_namespace_declare(&rootns, NULL, NULL);
+
+    parameter_integer_declare(&param, &rootns, "param");
+    parameter_integer_set(&param, 14);
+
+    mock().expectOneCall("error").withParameter("id", "param");
+    parameter_msgpack_write_cmp(&rootns, &ctx, log_problematic_id_callback, NULL);
+
+    mock().checkExpectations();
 }

--- a/tests/msgpack_test.cpp
+++ b/tests/msgpack_test.cpp
@@ -152,6 +152,26 @@ TEST(MessagePackTestGroup, TestWrite)
     CHECK_EQUAL(42., val);
 }
 
+TEST(MessagePackTestGroup, TestUndefinedValuesAreIgnored)
+{
+    uint32_t size;
+    char name[128];
+    parameter_scalar_set(&a_bar, 40.);
+
+    CHECK_FALSE(parameter_defined(&a_baz));
+    CHECK_TRUE(parameter_defined(&a_bar));
+
+    parameter_msgpack_write_cmp(&a, &ctx, msgpack_error_cb, NULL);
+    cmp_mem_access_set_pos(&mem, 0);
+
+    CHECK_TRUE(cmp_read_map(&ctx, &size));
+    CHECK_EQUAL(1, size);
+
+    size = sizeof(name);
+    CHECK_TRUE(cmp_read_str(&ctx, name, &size));
+    STRCMP_EQUAL(name, "bar");
+}
+
 TEST(MessagePackTestGroup, TestWriteVector)
 {
     uint32_t map_size;
@@ -281,7 +301,7 @@ TEST(MessagePackTestGroup, TestWriteUnknownParameter)
 
     parameter_namespace_declare(&rootns, NULL, NULL);
 
-    parameter_integer_declare(&bad_param, &rootns, "bad_param");
+    parameter_integer_declare_with_default(&bad_param, &rootns, "bad_param", 40);
 
     // Bogus type
     bad_param.type = 99;

--- a/tests/msgpack_test.cpp
+++ b/tests/msgpack_test.cpp
@@ -309,3 +309,22 @@ TEST(MessagePackTestGroup, TestWriteNotEnoughSpaceLeft)
 
     mock().checkExpectations();
 }
+
+TEST(MessagePackTestGroup, TestBackAndForth)
+{
+    // Write an initial value
+    parameter_integer_set(&a_baz, 42);
+
+    // Save it as messagepack
+    parameter_msgpack_write_cmp(&rootns, &ctx, msgpack_error_cb, NULL);
+    cmp_mem_access_set_pos(&mem, 0);
+
+    // Change it
+    parameter_integer_set(&a_baz, 99);
+
+    // Load it from messagepack
+    parameter_msgpack_read_cmp(&rootns, &ctx, msgpack_error_cb, NULL);
+
+    // Check that it had its old value
+    CHECK_EQUAL(42, parameter_integer_get(&a_baz));
+}


### PR DESCRIPTION
This implements serialization of the configuration tree as messagepack.

Not too sure about changing the assertion in parameter.c but it seemed to work fine on my test case.