### PR TITLE
Correctly discard unknown parameters

### DIFF
--- a/parameter_msgpack.c
+++ b/parameter_msgpack.c
@@ -26,11 +26,11 @@ static int discard_msgpack_element(cmp_object_t *obj,
     case CMP_TYPE_SINT32:
     case CMP_TYPE_SINT64:
     case CMP_TYPE_NEGATIVE_FIXNUM:
-        return true;
+        return 0;
     default:
         // todo discarding namespaces / vectors won't work
         err_cb(err_arg, err_id, "discarding failed");
-        return false;
+        return -1;
   }
 }
 

--- a/tests/msgpack_test.cpp
+++ b/tests/msgpack_test.cpp
@@ -386,3 +386,22 @@ TEST(MessagePackTestGroup, TestBackAndForth)
     // Check that it had its old value
     CHECK_EQUAL(42, parameter_integer_get(&a_baz));
 }
+
+TEST(MessagePackTestGroup, IgnoresUnknownParameters)
+{
+    parameter_scalar_set(&a_foo, 42);
+
+    cmp_write_map(&ctx, 1);
+    cmp_write_str(&ctx, "a", 1);
+    cmp_write_map(&ctx, 2);
+    cmp_write_str(&ctx, "b", 1);
+    cmp_write_float(&ctx, 38.);
+    cmp_write_str(&ctx, "foo", 3);
+    cmp_write_float(&ctx, 12.);
+
+    cmp_mem_access_set_pos(&mem, 0);
+
+    parameter_msgpack_read_cmp(&rootns, &ctx, NULL, NULL);
+
+    CHECK_EQUAL(12., parameter_scalar_get(&a_foo));
+}


### PR DESCRIPTION
Prior to this the semantics were inverted on wether an element could be
skipped or not. This caused issues when loading serialized trees that do
contained extra elements.

Also added a test to show the intended behavior and prevent regression.